### PR TITLE
Update Dapper reference to resolve #2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ ClientBin/
 *.pfx
 *.publishsettings
 node_modules/
+.vs/
 
 # RIA/Silverlight projects
 Generated_Code/

--- a/src/Dapper.AmbientContext/AmbientDbContext.ProxyAsync.cs
+++ b/src/Dapper.AmbientContext/AmbientDbContext.ProxyAsync.cs
@@ -385,6 +385,37 @@ namespace Dapper.AmbientContext
         /// Execute a single-row query asynchronously using .NET 4.5 
         /// <see cref="System.Threading.Tasks.Task"/>.
         /// </summary>
+        /// <param name="sql">
+        /// The SQL statement to execute.
+        /// </param>
+        /// <param name="param">
+        /// The SQL query parameters.
+        /// </param>
+        /// <param name="commandTimeout">
+        /// The number of seconds before command execution timeout.
+        /// </param>
+        /// <param name="commandType">
+        /// Determines whether the command is a stored procedure or a batch.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation.
+        /// </returns>
+        public async Task<dynamic> QueryFirstOrDefaultAsync(
+            string sql,
+            object param = null,
+            int? commandTimeout = null,
+            CommandType? commandType = null)
+        {
+            await PrepareConnectionAndTransactionAsync(default(CancellationToken)).ConfigureAwait(false);
+
+            return await Connection.QueryFirstOrDefaultAsync(sql, param, Transaction, commandTimeout, commandType)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Execute a single-row query asynchronously using .NET 4.5 
+        /// <see cref="System.Threading.Tasks.Task"/>.
+        /// </summary>
         /// <typeparam name="T">
         /// The return type.
         /// </typeparam>
@@ -412,6 +443,37 @@ namespace Dapper.AmbientContext
             await PrepareConnectionAndTransactionAsync(default(CancellationToken)).ConfigureAwait(false);
 
             return await Connection.QuerySingleAsync<T>(sql, param, Transaction, commandTimeout, commandType)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Execute a single-row query asynchronously using .NET 4.5 
+        /// <see cref="System.Threading.Tasks.Task"/>.
+        /// </summary>
+        /// <param name="sql">
+        /// The SQL statement to execute.
+        /// </param>
+        /// <param name="param">
+        /// The SQL query parameters.
+        /// </param>
+        /// <param name="commandTimeout">
+        /// The number of seconds before command execution timeout.
+        /// </param>
+        /// <param name="commandType">
+        /// Determines whether the command is a stored procedure or a batch.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation.
+        /// </returns>
+        public async Task<dynamic> QuerySingleAsync(
+            string sql,
+            object param = null,
+            int? commandTimeout = null,
+            CommandType? commandType = null)
+        {
+            await PrepareConnectionAndTransactionAsync(default(CancellationToken)).ConfigureAwait(false);
+
+            return await Connection.QuerySingleAsync(sql, param, Transaction, commandTimeout, commandType)
                 .ConfigureAwait(false);
         }
 
@@ -446,6 +508,89 @@ namespace Dapper.AmbientContext
             await PrepareConnectionAndTransactionAsync(default(CancellationToken)).ConfigureAwait(false);
 
             return await Connection.QuerySingleOrDefaultAsync<T>(sql, param, Transaction, commandTimeout, commandType)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Execute a single-row query asynchronously using .NET 4.5
+        /// <see cref="System.Threading.Tasks.Task"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The return type.
+        /// </typeparam>
+        /// <param name="command">
+        /// The SQL command definition.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation.
+        /// </returns>
+        public async Task<T> QuerySingleOrDefaultAsync<T>(CommandDefinition command)
+        {
+            await PrepareConnectionAndTransactionAsync(default(CancellationToken)).ConfigureAwait(false);
+
+            return await Connection.QuerySingleOrDefaultAsync<T>(command)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Execute a single-row query asynchronously using .NET 4.5
+        /// <see cref="System.Threading.Tasks.Task"/>.
+        /// </summary>
+        /// <param name="sql">
+        /// The SQL statement to execute.
+        /// </param>
+        /// <param name="param">
+        /// The SQL query parameters.
+        /// </param>
+        /// <param name="commandTimeout">
+        /// The number of seconds before command execution timeout.
+        /// </param>
+        /// <param name="commandType">
+        /// Determines whether the command is a stored procedure or a batch.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation.
+        /// </returns>
+        public async Task<dynamic> QuerySingleOrDefaultAsync(
+            string sql,
+            object param = null,
+            int? commandTimeout = null,
+            CommandType? commandType = null)
+        {
+            await PrepareConnectionAndTransactionAsync(default(CancellationToken)).ConfigureAwait(false);
+
+            return await Connection.QuerySingleOrDefaultAsync(sql, param, Transaction, commandTimeout, commandType)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Execute a single-row query asynchronously using .NET 4.5
+        /// <see cref="System.Threading.Tasks.Task"/>.
+        /// </summary>
+        /// <param name="sql">
+        /// The SQL statement to execute.
+        /// </param>
+        /// <param name="param">
+        /// The SQL query parameters.
+        /// </param>
+        /// <param name="commandTimeout">
+        /// The number of seconds before command execution timeout.
+        /// </param>
+        /// <param name="commandType">
+        /// Determines whether the command is a stored procedure or a batch.
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation.
+        /// </returns>
+        public async Task<dynamic> QueryFirstAsync(
+            string sql,
+            object param = null,
+            int? commandTimeout = null,
+            CommandType? commandType = null)
+        {
+            await PrepareConnectionAndTransactionAsync(default(CancellationToken)).ConfigureAwait(false);
+
+            return await Connection.QueryFirstAsync(sql, param, Transaction, commandTimeout, commandType)
                 .ConfigureAwait(false);
         }
 

--- a/src/Dapper.AmbientContext/Dapper.AmbientContext.csproj
+++ b/src/Dapper.AmbientContext/Dapper.AmbientContext.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Ambient context implementation for Dapper.NET</Description>
     <Copyright>Copyright Sergey Akopov</Copyright>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <Authors>Sergey Akopov</Authors>
     <TargetFrameworks>net451;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Dapper.AmbientContext</AssemblyName>

--- a/src/Dapper.AmbientContext/Dapper.AmbientContext.csproj
+++ b/src/Dapper.AmbientContext/Dapper.AmbientContext.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright Sergey Akopov</Copyright>
     <VersionPrefix>1.4.0</VersionPrefix>
     <Authors>Sergey Akopov</Authors>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Dapper.AmbientContext</AssemblyName>
     <PackageId>Dapper.AmbientContext</PackageId>
     <PackageTags>dapper;ambient;context</PackageTags>
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.2" />
+    <PackageReference Include="Dapper" Version="1.50.4" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/src/Dapper.AmbientContext/Storage/AsyncLocalContextStorage.cs
+++ b/src/Dapper.AmbientContext/Storage/AsyncLocalContextStorage.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD1_3
+﻿#if NETSTANDARD1_3 || NETSTANDARD2_0
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="LogicalCallContextStorage.cs">
 //   Copyright (c) 2016 Sergey Akopov

--- a/src/Dapper.AmbientContext/Storage/ContextualStorageHelper.cs
+++ b/src/Dapper.AmbientContext/Storage/ContextualStorageHelper.cs
@@ -78,7 +78,7 @@ namespace Dapper.AmbientContext.Storage
         /// </returns>
         public IImmutableStack<IAmbientDbContext> GetStack()
         {
-#if NET45
+#if NET451
             var crossReferenceKey = _storage.GetValue<ContextualStorageItem>(AmbientDbContextStorageKey.Key);
 #else
             var crossReferenceKey = _storage.GetValue<string>(AmbientDbContextStorageKey.Key);
@@ -92,7 +92,7 @@ namespace Dapper.AmbientContext.Storage
 
             IImmutableStack<IAmbientDbContext> value;
 
-#if NET45
+#if NET451
             AmbientDbContextTable.TryGetValue(crossReferenceKey.Value, out value);
 #else
             AmbientDbContextTable.TryGetValue(crossReferenceKey, out value);
@@ -108,7 +108,7 @@ namespace Dapper.AmbientContext.Storage
         /// </param>
         public void SaveStack(IImmutableStack<IAmbientDbContext> stack)
         {
-#if NET45
+#if NET451
             var crossReferenceKey = _storage.GetValue<ContextualStorageItem>(AmbientDbContextStorageKey.Key);
 #else
             var crossReferenceKey = _storage.GetValue<string>(AmbientDbContextStorageKey.Key);
@@ -123,7 +123,7 @@ namespace Dapper.AmbientContext.Storage
             IImmutableStack<IAmbientDbContext> value;
 
             // Drop the existing key and recreate because the value is immutable
-#if NET45
+#if NET451
             if (AmbientDbContextTable.TryGetValue(crossReferenceKey.Value, out value))
             {
                 AmbientDbContextTable.Remove(crossReferenceKey.Value);
@@ -146,7 +146,7 @@ namespace Dapper.AmbientContext.Storage
         /// </summary>
         private void Initialize()
         {
-#if NET45
+#if NET451
             var crossReferenceKey = _storage.GetValue<ContextualStorageItem>(AmbientDbContextStorageKey.Key);
 #else
             var crossReferenceKey = _storage.GetValue<string>(AmbientDbContextStorageKey.Key);
@@ -154,14 +154,14 @@ namespace Dapper.AmbientContext.Storage
 
             if (crossReferenceKey == null)
             {
-#if NET45
+#if NET451
                 crossReferenceKey = new ContextualStorageItem(Guid.NewGuid().ToString("N"));
 #else
                 crossReferenceKey = Guid.NewGuid().ToString("N");
 #endif
                 _storage.SetValue(AmbientDbContextStorageKey.Key, crossReferenceKey);
 
-#if NET45
+#if NET451
                 AmbientDbContextTable.Add(crossReferenceKey.Value, ImmutableStack.Create<IAmbientDbContext>());
 #else
                 AmbientDbContextTable.Add(crossReferenceKey, ImmutableStack.Create<IAmbientDbContext>());
@@ -169,7 +169,7 @@ namespace Dapper.AmbientContext.Storage
             }
         }
 
-#if NET45
+#if NET451
         /// <summary>
         /// Wraps values in storage to enable access across AppDomains. While all storage
         /// mechanisms will use the same approach, it is only required for the Logical 

--- a/src/Dapper.AmbientContext/Storage/LogicalCallContextStorage.cs
+++ b/src/Dapper.AmbientContext/Storage/LogicalCallContextStorage.cs
@@ -24,7 +24,7 @@
 //   Represents the type that implements storage on top of logical call context.
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
-#if NET45
+#if NET451
 namespace Dapper.AmbientContext.Storage
 {
     using System.Runtime.Remoting.Messaging;

--- a/test/Dapper.AmbientContext.Tests/AmbientDbContextFactoryTests.cs
+++ b/test/Dapper.AmbientContext.Tests/AmbientDbContextFactoryTests.cs
@@ -14,7 +14,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -56,7 +56,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());

--- a/test/Dapper.AmbientContext.Tests/AmbientDbContextLocatorTests.cs
+++ b/test/Dapper.AmbientContext.Tests/AmbientDbContextLocatorTests.cs
@@ -14,7 +14,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -48,7 +48,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -89,7 +89,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());

--- a/test/Dapper.AmbientContext.Tests/AmbientDbContextStorageProviderTests.cs
+++ b/test/Dapper.AmbientContext.Tests/AmbientDbContextStorageProviderTests.cs
@@ -28,7 +28,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());

--- a/test/Dapper.AmbientContext.Tests/AmbientDbContextTests.cs
+++ b/test/Dapper.AmbientContext.Tests/AmbientDbContextTests.cs
@@ -16,7 +16,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -69,7 +69,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -131,7 +131,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -194,7 +194,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -252,7 +252,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -328,7 +328,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -408,7 +408,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -488,7 +488,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -582,7 +582,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -650,7 +650,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -711,7 +711,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -767,7 +767,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -834,7 +834,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -902,7 +902,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -964,7 +964,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -1030,7 +1030,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -1091,7 +1091,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -1147,7 +1147,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -1214,7 +1214,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -1282,7 +1282,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());

--- a/test/Dapper.AmbientContext.Tests/ContextualStorageHelperTests.cs
+++ b/test/Dapper.AmbientContext.Tests/ContextualStorageHelperTests.cs
@@ -14,7 +14,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 _storage = new LogicalCallContextStorage();
 #else
                 _storage = new AsyncLocalContextStorage();
@@ -50,7 +50,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
@@ -84,13 +84,16 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
 #else
                 AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
 #endif
 
-                _expectedAmbientDbContext = new Mock<IAmbientDbContext>().Object;
+                _dbConnectionMock = new Mock<IDbConnection>();
+                _dbConnectionMock.Setup(mock => mock.State).Returns(() => ConnectionState.Closed);
+
+                _expectedAmbientDbContext = new AmbientDbContext(_dbConnectionMock.Object, true, true, IsolationLevel.ReadCommitted);
 
                 _contextualStorageHelper = new ContextualStorageHelper(AmbientDbContextStorageProvider.Storage);
 
@@ -119,6 +122,7 @@ namespace Dapper.AmbientContext.Tests
                 AmbientDbContextStorageProvider.SetStorage(null);
             };
 
+            private static Mock<IDbConnection> _dbConnectionMock;
             private static IAmbientDbContext _expectedAmbientDbContext;
             private static IImmutableStack<IAmbientDbContext> _returnedAmbientDbContextStack;
             private static ContextualStorageHelper _contextualStorageHelper;

--- a/test/Dapper.AmbientContext.Tests/Dapper.AmbientContext.Tests.csproj
+++ b/test/Dapper.AmbientContext.Tests/Dapper.AmbientContext.Tests.csproj
@@ -1,15 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0' AND '$(TargetFramework)' != 'netcoreapp2.0'">Full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Machine.Specifications" Version="0.12.0" />
     <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.6.1" />
     <PackageReference Include="Machine.Specifications.Should" Version="0.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Moq" Version="4.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
+    <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/test/Dapper.AmbientContext.Tests/LogicalCallContextStorageTests.cs
+++ b/test/Dapper.AmbientContext.Tests/LogicalCallContextStorageTests.cs
@@ -10,7 +10,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 _storage = new LogicalCallContextStorage();
 #else
                 _storage = new AsyncLocalContextStorage();
@@ -43,7 +43,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 _storage = new LogicalCallContextStorage();
 #else
                 _storage = new AsyncLocalContextStorage();
@@ -69,7 +69,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 _storage = new LogicalCallContextStorage();
 #else
                 _storage = new AsyncLocalContextStorage();
@@ -102,7 +102,7 @@ namespace Dapper.AmbientContext.Tests
         {
             Establish context = () =>
             {
-#if NET45
+#if NET451
                 _storage = new LogicalCallContextStorage();
 #else
                 _storage = new AsyncLocalContextStorage();


### PR DESCRIPTION
1. Resolve #2 by updating Dapper to latest. 
2. Add NETStandard 2.0 target to match Dapper.
3. Fix an odd issue with tests not being discovered in VS17 Test Explorer.
4. Add more of Dapper's async extension methods.