### PR TITLE
fix: disable semantic-release GitHub plugin commenting

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -47,7 +47,10 @@
     [
       "@semantic-release/github",
       {
-        "assets": []
+        "assets": [],
+        "successComment": false,
+        "failComment": false,
+        "releasedLabels": false
       }
     ]
   ]


### PR DESCRIPTION
## Summary

Fixes semantic-release failures when trying to comment on closed PRs.

## Problem

After v2.0.0 release, semantic-release failed with:
```
Error: Could not resolve to an Issue with the number of 14.
```

The `@semantic-release/github` plugin was trying to comment on PR #14 (referenced as "Resolves #14" in commit messages), but:
- PR #14 is closed
- The GraphQL query fails to resolve it

## Solution

Disable automatic commenting features in the GitHub plugin:
- `successComment: false` - Don't comment on issues/PRs when released
- `failComment: false` - Don't comment on issues/PRs when release fails  
- `releasedLabels: false` - Don't add labels to released issues/PRs

This is a common configuration for projects that don't need semantic-release to comment on every referenced issue/PR.

## Changes

- Added configuration to `.releaserc.json` to disable GitHub plugin commenting

## Impact

- ✅ Semantic-release won't fail when referencing closed PRs
- ✅ Releases and tags still created normally
- ℹ️ No automatic comments on issues/PRs (manual GitHub release notes still created)