### PR TITLE
feat: add IServiceCollection extension methods for easy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,13 @@ public class SqlConnectionFactory : IDbConnectionFactory
 ### 2. Register services in your DI container
 
 ```csharp
-// Configure services
-services.AddSingleton<IDbConnectionFactory>(new SqlConnectionFactory(connectionString));
-services.AddSingleton<IAmbientDbContextLocator, AmbientDbContextLocator>();
-services.AddTransient<IAmbientDbContextFactory, AmbientDbContextFactory>();
+using Dapper.AmbientContext.Extensions;
+
+// With connection factory instance
+services.AddDapperAmbientContext(new SqlConnectionFactory(connectionString));
+
+// OR with connection factory type
+services.AddDapperAmbientContext<SqlConnectionFactory>(connectionString);
 
 // Register your repositories
 services.AddTransient<IUserRepository, UserRepository>();

--- a/src/Dapper.AmbientContext/Dapper.AmbientContext.csproj
+++ b/src/Dapper.AmbientContext/Dapper.AmbientContext.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.151" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Dapper.AmbientContext/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Dapper.AmbientContext/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,105 @@
+using System;
+using Dapper.AmbientContext.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Dapper.AmbientContext.Extensions
+{
+    /// <summary>
+    /// Extension methods for configuring Dapper.AmbientContext services.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds Dapper.AmbientContext services to the specified <see cref="IServiceCollection"/> using a connection factory instance.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+        /// <param name="connectionFactory">The database connection factory instance.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> or <paramref name="connectionFactory"/> is null.</exception>
+        /// <remarks>
+        /// This method automatically configures the appropriate storage provider based on the target framework:
+        /// <list type="bullet">
+        /// <item><description><see cref="AsyncLocalContextStorage"/> for .NET Core, .NET 5+</description></item>
+        /// <item><description><see cref="LogicalCallContextStorage"/> for .NET Framework</description></item>
+        /// </list>
+        /// </remarks>
+        public static IServiceCollection AddDapperAmbientContext(
+            this IServiceCollection services,
+            IDbConnectionFactory connectionFactory)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (connectionFactory == null)
+            {
+                throw new ArgumentNullException(nameof(connectionFactory));
+            }
+
+            ConfigureStorage();
+
+            services.AddSingleton(connectionFactory);
+            services.AddSingleton<IAmbientDbContextLocator, AmbientDbContextLocator>();
+            services.AddTransient<IAmbientDbContextFactory, AmbientDbContextFactory>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds Dapper.AmbientContext services to the specified <see cref="IServiceCollection"/> using a connection factory type.
+        /// </summary>
+        /// <typeparam name="TConnectionFactory">The type of database connection factory to register.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add services to.</param>
+        /// <param name="connectionString">The database connection string to pass to the factory constructor.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="services"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString"/> is null or empty.</exception>
+        /// <remarks>
+        /// This method automatically configures the appropriate storage provider based on the target framework:
+        /// <list type="bullet">
+        /// <item><description><see cref="AsyncLocalContextStorage"/> for .NET Core, .NET 5+</description></item>
+        /// <item><description><see cref="LogicalCallContextStorage"/> for .NET Framework</description></item>
+        /// </list>
+        /// The factory type must have a constructor that accepts a connection string parameter.
+        /// </remarks>
+        public static IServiceCollection AddDapperAmbientContext<TConnectionFactory>(
+            this IServiceCollection services,
+            string connectionString)
+            where TConnectionFactory : class, IDbConnectionFactory
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentException("Connection string cannot be null or empty.", nameof(connectionString));
+            }
+
+            ConfigureStorage();
+
+            services.TryAddSingleton<TConnectionFactory>();
+            services.AddSingleton<IDbConnectionFactory>(sp =>
+            {
+                var factory = ActivatorUtilities.CreateInstance<TConnectionFactory>(sp, connectionString);
+                return factory;
+            });
+            services.AddSingleton<IAmbientDbContextLocator, AmbientDbContextLocator>();
+            services.AddTransient<IAmbientDbContextFactory, AmbientDbContextFactory>();
+
+            return services;
+        }
+
+        private static void ConfigureStorage()
+        {
+#if NET462
+            AmbientDbContextStorageProvider.SetStorage(new LogicalCallContextStorage());
+#else
+            AmbientDbContextStorageProvider.SetStorage(new AsyncLocalContextStorage());
+#endif
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds convenience extension methods to simplify dependency injection setup for consumers.

## What's New
Two new extension methods in `Dapper.AmbientContext.Extensions`:

**Option 1: Register with factory instance**
```csharp
services.AddDapperAmbientContext(new SqlConnectionFactory(connectionString));
```

**Option 2: Register with factory type**
```csharp
services.AddDapperAmbientContext<SqlConnectionFactory>(connectionString);
```

## Benefits
- **Simpler setup** - One line instead of manually registering 3 services + storage configuration
- **Automatic storage configuration** - Detects target framework and sets appropriate storage provider
  - `AsyncLocalContextStorage` for .NET Core/.NET 5+
  - `LogicalCallContextStorage` for .NET Framework
- **Type-safe** - Compile-time validation of registration
- **Flexible** - Two approaches to suit different scenarios

## Changes
- Added `ServiceCollectionExtensions.cs` with `AddDapperAmbientContext` methods
- Added full XML documentation for both extension methods
- Added `Microsoft.Extensions.DependencyInjection.Abstractions` package reference (v2.0.0 for broad compatibility)
- Updated README to show the extension method approach as the primary setup method

## Testing
- Build succeeds on both net462 and netstandard2.0
- All existing unit tests (100) and integration tests (7) pass